### PR TITLE
Release v008

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -72,6 +72,6 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    params.require(:conference).permit(:organizer_id, :start_date, :end_date, :venue, :venue_url, :city, :state)
+    params.require(:conference).permit(:organizer_id, :url, :start_date, :end_date, :venue, :venue_url, :city, :state)
   end
 end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -56,7 +56,11 @@ class ConferencesController < ApplicationController
   end
 
   def destroy
-    @conference.destroy
+    if can?(:destroy, @conference) && @conference.presentations.empty?
+      @conference.destroy
+    else
+      flash[:notice] = "That conference can't be deleted because it has presentations linked to it."
+    end
 
     redirect_to conferences_path
   end

--- a/app/controllers/organizers_controller.rb
+++ b/app/controllers/organizers_controller.rb
@@ -43,7 +43,11 @@ class OrganizersController < ApplicationController
   end
 
   def destroy
-    @organizer.destroy
+    if can?(:destroy, @organizer) && @organizer.conferences.empty?
+      @organizer.destroy
+    else
+      flash[:notice] = "Organizer can't be deleted because it owns conferences."
+    end
 
     redirect_to organizers_path
   end

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -56,7 +56,11 @@ class SpeakersController < ApplicationController
   end
 
   def destroy
-    @speaker.destroy
+    if can?(:destroy, @speaker) && @speaker.presentations.empty?
+      @speaker.destroy
+    else
+      flash[:notice] = "Speaker can't be destroyed because it is associated with presentations."
+    end
 
     redirect_to speakers_path
   end

--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -7,4 +7,18 @@ module PresentationsHelper
       "#{ publication.format }, #{ publication.published_on.year }"
     end
   end
+
+  def google_safe(text)
+    searchable_title = text.gsub(" ", "+")                        # Google uses pluses for spaces
+    searchable_title = searchable_title.delete("^a-zA-Z0-9+\-")   # Add the first speaker as an additional term
+    return searchable_title
+  end
+
+  # Builds a URL for Google Search that will search on the title and first presenter, to provide an easy way
+  # to find copies of the presentation online
+  def google_search_url(presentation)
+    url = "https://www.google.com/search?&q=%22#{ google_safe(presentation.name) }%22"
+    url += "+%22#{ google_safe(presentation.speakers.first.name) }%22" if presentation.speakers.present?
+    return url
+  end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,7 +12,7 @@ class Conference < ApplicationRecord
   validates :organizer_id, :start_date, :end_date, presence: true
 
   def location
-    "#{city}, #{state}"
+    [city, state].join(', ')
   end
 
   def name

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -3,10 +3,10 @@ class Conference < ApplicationRecord
   belongs_to  :organizer
   belongs_to  :creator,   class_name: "User"
 
-  has_many :presentations
+  has_many :presentations                       # currently, conferences with presentations can't be destroyed
   has_many :speakers, through: :presentations
 
-  has_many :conference_users
+  has_many :conference_users,                   :dependent => :destroy
   has_many :users, through: :conference_users
 
   validates :organizer_id, :start_date, :end_date, presence: true

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -2,9 +2,9 @@ class Presentation < ApplicationRecord
 
   belongs_to  :conference
 
-  has_many    :publications
+  has_many    :publications,            :dependent => :destroy
 
-  has_many    :presentation_speakers
+  has_many    :presentation_speakers,   :dependent => :destroy
   has_many    :speakers, through: :presentation_speakers
 
   validates :name, presence: true

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -2,7 +2,7 @@ class Speaker < ApplicationRecord
 
   belongs_to  :creator,   class_name: "User"
 
-  has_many :presentation_speakers
+  has_many :presentation_speakers,                           :dependent => :destroy
   has_many :presentations, through: :presentation_speakers
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
 
   belongs_to :role
 
-  has_many :conference_users
+  has_many :conference_users,                           :dependent => :destroy
   has_many :conferences, through: :conference_users
 
   validates :name, presence: true

--- a/app/views/conferences/_conference.html.haml
+++ b/app/views/conferences/_conference.html.haml
@@ -2,6 +2,9 @@
   %td= link_to(truncate(conference.name, length: 40), conference_path(conference))
   %td= date_span conference
   %td= conference.location
+  %td{ align: 'center' }
+    - if conference.url.present?
+      = link_to icon('file-o'), conference.url, target: '_blank'
 
   %td{width: 120}
     - if can? :edit, conference

--- a/app/views/conferences/_conference.html.haml
+++ b/app/views/conferences/_conference.html.haml
@@ -8,4 +8,5 @@
       = link_to edit_conference_path(conference), :class => "btn btn-sm" do
         = icon 'edit', class: 'fa-fw'
         Edit
+    - if can?(:destroy, conference) && conference.presentations.empty?
       = link_to icon('trash', class: 'fa-fw'), conference_path(conference), :method => :delete, :class => "btn btn-sm btn-danger", :data => { :confirm => 'Are you sure?' }, :post => true

--- a/app/views/conferences/_form_fields.html.haml
+++ b/app/views/conferences/_form_fields.html.haml
@@ -1,5 +1,5 @@
 = f.input :organizer_id, as: 'select', collection: @organizer_selections, include_blank: false
-= f.input :url, hint: "A link where the schedule can be found"
+= f.input :url, input_html: { autocomplete: "off" }, hint: "A link where the schedule can be found"
 = f.input :start_date, as: :date, start_year: 1983, end_year: Date.today.year, order: [:month, :day, :year]
 = f.input :end_date, as: :date, start_year: 1983, end_year: Date.today.year, order: [:month, :day, :year]
 = f.input :venue

--- a/app/views/conferences/_form_fields.html.haml
+++ b/app/views/conferences/_form_fields.html.haml
@@ -1,4 +1,5 @@
 = f.input :organizer_id, as: 'select', collection: @organizer_selections, include_blank: false
+= f.input :url, hint: "A link where the schedule can be found"
 = f.input :start_date, as: :date, start_year: 1983, end_year: Date.today.year, order: [:month, :day, :year]
 = f.input :end_date, as: :date, start_year: 1983, end_year: Date.today.year, order: [:month, :day, :year]
 = f.input :venue

--- a/app/views/conferences/_table_head.html.haml
+++ b/app/views/conferences/_table_head.html.haml
@@ -2,4 +2,5 @@
   %th Conference
   %th Date
   %th Location
+  %th{ style: 'text-align: center' } Program
   %th

--- a/app/views/conferences/edit.html.haml
+++ b/app/views/conferences/edit.html.haml
@@ -5,4 +5,4 @@
   .col-md-12
     = simple_form_for @conference do |f|
       = render :partial => "form_fields", :locals => {:f => f}
-      = save_or_cancel f, conferences_path, 'Save'
+      = save_or_cancel f, conference_path(@conference), 'Save'

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -2,12 +2,6 @@
 .row
   .col-md-12
     %h4= full_name_with_date(@conference)
-    - if @conference.venue_url.present?
-      = link_to @conference.venue, @conference.venue_url
-    - else
-      = @conference.venue
-    = @conference.location
-
     - if current_user
       .pull-right
         - if current_user.attended? @conference
@@ -19,6 +13,21 @@
             = f.input :conference_id, as: :hidden, input_html: { value: @conference.id }
             = f.input :user_id, as: :hidden, input_html: { value:current_user.id }
             = f.submit attendance_invitation_message(@conference)
+    %b Venue:
+    - if @conference.venue_url.present?
+      = link_to @conference.venue, @conference.venue_url, target: '_blank'
+    - else
+      = @conference.venue
+    - if @conference.location.present?
+      &mdash;
+      = @conference.location
+    %p
+      %b Program:
+      - if @conference.url.present?
+        = link_to icon('file-o', class: 'fa-fw'), @conference.url, target: '_blank'
+      - else
+        %i none
+
 .row
   .col-md-12
     %h4 Presentations

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -13,21 +13,26 @@
             = f.input :conference_id, as: :hidden, input_html: { value: @conference.id }
             = f.input :user_id, as: :hidden, input_html: { value:current_user.id }
             = f.submit attendance_invitation_message(@conference)
-    %b Venue:
-    - if @conference.venue_url.present?
-      = link_to @conference.venue, @conference.venue_url, target: '_blank'
-    - else
-      = @conference.venue
-    - if @conference.location.present?
-      &mdash;
-      = @conference.location
+    %p
+      %b Venue:
+      - if @conference.venue_url.present?
+        = link_to @conference.venue, @conference.venue_url, target: '_blank'
+      - else
+        = @conference.venue
+      - if @conference.location.present?
+        &mdash;
+        = @conference.location
     %p
       %b Program:
       - if @conference.url.present?
         = link_to icon('file-o', class: 'fa-fw'), @conference.url, target: '_blank'
       - else
         %i none
-
+    %p
+      %b Members Attending:
+      = @conference.users.length
+      - if @conference.users.length > 0 && current_user
+        = link_to icon('users', class: 'fa-fw'), conference_users_path(conference_id: @conference.id)
 .row
   .col-md-12
     %h4 Presentations
@@ -44,13 +49,6 @@
             - presentation.speakers.each do |speaker|
               = link_to speaker.name, speaker_path(speaker)
 
-.row
-  .col-md-12
-    %h4 Attendees
-    %p
-      = @conference.users.length
-      - if @conference.users.length > 0
-        = link_to "Show", conference_users_path(conference_id: @conference.id), class: 'btn btn-sm btn-secondary'
 .row
   .col-md-12
     .form-actions

--- a/app/views/conferences/show.html.haml
+++ b/app/views/conferences/show.html.haml
@@ -52,11 +52,11 @@
 .row
   .col-md-12
     .form-actions
-      - if can? :create, @presentation
+      - if can? :create, Presentation
         = link_to "Add a Presentation", new_presentation_path(conference_id: @conference.id), :class => "btn btn-secondary"
       - if can? :edit, @conference
         = link_to "Edit", edit_conference_path(@conference), :class => "btn btn-secondary"
       = link_to "Done", conferences_path, :class => "btn btn-primary"
       .pull-right
-        - if can? :destroy, @conference
+        - if can?(:destroy, @conference) && @conference.presentations.empty?
           = link_to icon('trash', '', class: 'fa-fw'), conference_path(@conference), :method => :delete, :class => "btn btn-danger", :data => { :confirm => 'Are you sure?' }, :post => true

--- a/app/views/presentations/_presentation.html.haml
+++ b/app/views/presentations/_presentation.html.haml
@@ -6,8 +6,9 @@
       = link_to presentation.conference_name, conference_path(presentation.conference)
   %td= presentation.formats
 
-  %td{width: 120}
+  %td{width: 140}
     - if can? :edit, presentation
+      = link_to icon('search', class: 'fa-fw'), google_search_url(presentation), target: "_blank"
       = link_to edit_presentation_path(presentation), :class => "btn btn-sm" do
         = icon 'edit', class: 'fa-fw'
         Edit

--- a/app/views/presentations/show.html.haml
+++ b/app/views/presentations/show.html.haml
@@ -23,14 +23,16 @@
 
     %p
       Publications:
-      = @presentation.publications.empty? ? "Not yet available" : ""
       %ul
+        - if @presentation.publications.empty?
+          %li
+            %i Not yet available
         - @presentation.publications.each do |publication|
           %li
             = format_and_date(publication)
             - if publication.notes.present?
               = " - #{ publication.notes }"
-
+        %li= link_to icon('search', 'Search for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
 - if can? :edit, @presentation
   .row
     .col-md-12

--- a/app/views/presentations/show.html.haml
+++ b/app/views/presentations/show.html.haml
@@ -48,9 +48,9 @@
         = link_to "Edit", edit_presentation_path(@presentation), :class => "btn btn-secondary"
         - if request.referrer.split('?').first == new_presentation_url # ignore any trailing params
           = link_to "Add Another", new_presentation_path(conference_id: @presentation.conference_id), :class => "btn btn-secondary"
-      = link_to "Manage Speakers", manage_speakers_presentation_path(@presentation), :class => "btn btn-primary"
-      = link_to "Manage Publications", manage_publications_presentation_path(@presentation), :class => "btn btn-primary"
-      = link_to "Done", presentations_path, :class => "btn btn-primary"
+      = link_to "Manage Speakers", manage_speakers_presentation_path(@presentation), :class => "btn btn-secondary"
+      = link_to "Manage Publications", manage_publications_presentation_path(@presentation), :class => "btn btn-secondary"
+      = link_to "Done", @presentation.conference_id.present? ? conference_path(@presentation.conference_id) : presentations_path, :class => "btn btn-primary"
       .pull-right
         - if can? :destroy, @presentation
           = link_to icon('trash', '', class: 'fa-fw'), presentation_path(@presentation), :method => :delete, :class => "btn btn-danger", :data => { :confirm => 'Are you sure?' }, :post => true

--- a/app/views/speakers/_speaker.html.haml
+++ b/app/views/speakers/_speaker.html.haml
@@ -6,4 +6,5 @@
       = link_to edit_speaker_path(speaker), :class => "btn btn-sm" do
         = icon 'edit', class: 'fa-fw'
         Edit
+    -if can?(:destroy, speaker) && speaker.presentations.empty?
       = link_to icon('trash', class: 'fa-fw'), speaker_path(speaker), :method => :delete, :class => "btn btn-sm btn-danger", :data => { :confirm => 'Are you sure?' }, :post => true

--- a/app/views/speakers/show.html.haml
+++ b/app/views/speakers/show.html.haml
@@ -25,5 +25,5 @@
           = link_to "Add Another", new_speaker_path, :class => "btn btn-secondary"
       = link_to "Done", speakers_path, :class => "btn btn-primary"
       .pull-right
-        - if can? :destroy, @speaker
+        - if can?(:destroy, @speaker) && @speaker.presentations.empty?
           = link_to icon('trash', '', class: 'fa-fw'), speaker_path(@speaker), :method => :delete, :class => "btn btn-danger", :data => { :confirm => 'Are you sure?' }, :post => true

--- a/db/migrate/20180717141930_add_url_to_conferences.rb
+++ b/db/migrate/20180717141930_add_url_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddUrlToConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column "conferences", :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_10_043556) do
+ActiveRecord::Schema.define(version: 2018_07_17_141930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2018_07_10_043556) do
     t.bigint "creator_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url"
     t.index ["creator_id"], name: "index_conferences_on_creator_id"
     t.index ["organizer_id"], name: "index_conferences_on_organizer_id"
   end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe ConferencesController, type: :controller do
     { start_date:   nil }
   }
 
+  let(:conference) { Conference.create! valid_attributes }
+
   setup :activate_authlogic
 
   before do
@@ -34,29 +36,25 @@ RSpec.describe ConferencesController, type: :controller do
   let(:valid_session) { {} }
 
   describe "when listing conferences" do
-    before do
-      @conference = Conference.create! valid_attributes
-    end
-
     it "assigns all conferences as @conferences" do
       get :index, params: {}
-      expect(assigns(:conferences)).to eq([@conference])
+      expect(assigns(:conferences)).to eq([conference])
     end
 
     context "with a search term" do
       it "finds conferences with organizer name matching" do
         get :index, params:{ search_term: 'Organ' }
-        expect(assigns(:conferences)).to eq([@conference])
+        expect(assigns(:conferences)).to eq([conference])
       end
 
       it "finds conferences with organizer series matching" do
         get :index, params:{ search_term: 'confe' }
-        expect(assigns(:conferences)).to eq([@conference])
+        expect(assigns(:conferences)).to eq([conference])
       end
 
       it "finds conferences with organizer abbbreviation matching" do
         get :index, params:{ search_term: 'OC' }
-        expect(assigns(:conferences)).to eq([@conference])
+        expect(assigns(:conferences)).to eq([conference])
       end
 
       it "it doesn't find non-matching conferences" do
@@ -68,7 +66,7 @@ RSpec.describe ConferencesController, type: :controller do
     context "with an auto-complete search term" do
       it "finds conferences with years matching the search term" do
         get :index, params:{ q: '2005' }
-        expect(assigns(:conferences)).to eq([@conference])
+        expect(assigns(:conferences)).to eq([conference])
       end
 
       it "it doesn't find non-matching conferences" do
@@ -80,7 +78,6 @@ RSpec.describe ConferencesController, type: :controller do
 
   describe "GET #show" do
     it "assigns the requested conference as @conference" do
-      conference = Conference.create! valid_attributes
       get :show, params: {id: conference.to_param}
       expect(assigns(:conference)).to eq(conference)
     end
@@ -95,7 +92,6 @@ RSpec.describe ConferencesController, type: :controller do
 
   describe "GET #edit" do
     it "assigns the requested conference as @conference" do
-      conference = Conference.create! valid_attributes
       get :edit, params: {id: conference.to_param}
       expect(assigns(:conference)).to eq(conference)
     end
@@ -141,14 +137,12 @@ RSpec.describe ConferencesController, type: :controller do
       }
 
       it "updates the requested conference" do
-        conference = Conference.create! valid_attributes
         expect(conference.start_date).to eq(valid_attributes[:start_date])
         put :update, params: {id: conference.to_param, conference: new_attributes}
         expect(assigns(:conference).start_date).to eq(new_attributes[:start_date])
       end
 
       it "redirects to the conference" do
-        conference = Conference.create! valid_attributes
         put :update, params: {id: conference.to_param, conference: valid_attributes}
         expect(response).to redirect_to(conference)
       end
@@ -156,13 +150,11 @@ RSpec.describe ConferencesController, type: :controller do
 
     context "with invalid params" do
       it "assigns the conference as @conference" do
-        conference = Conference.create! valid_attributes
         put :update, params: {id: conference.to_param, conference: invalid_attributes}
         expect(assigns(:conference)).to eq(conference)
       end
 
       it "re-renders the 'edit' template" do
-        conference = Conference.create! valid_attributes
         put :update, params: {id: conference.to_param, conference: invalid_attributes}
         expect(response).to render_template("edit")
       end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -170,15 +170,32 @@ RSpec.describe ConferencesController, type: :controller do
   end
 
   describe "DELETE #destroy" do
+
+    let!(:conference) { Conference.create! valid_attributes }
+
     it "destroys the requested conference" do
-      conference = Conference.create! valid_attributes
+      # preconditions that should be satisfied by setup
+      # expect(@current_user.admin?).to be_truthy
+      # expect(conference.presentations).to be_empty
+
       expect {
         delete :destroy, params: {id: conference.to_param}
       }.to change(Conference, :count).by(-1)
     end
 
+    context "with a conference containing presentations" do
+
+      let!(:presentation) { create :presentation, conference_id: conference.id }
+
+      it "does not destroy the requested conference" do
+        expect {
+          delete :destroy, params: {id: conference.to_param}
+        }.not_to change(Conference, :count)
+
+      end
+    end
+
     it "redirects to the conferences list" do
-      conference = Conference.create! valid_attributes
       delete :destroy, params: {id: conference.to_param}
       expect(response).to redirect_to(conferences_url)
     end

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -136,34 +136,38 @@ RSpec.describe ConferencesController, type: :controller do
         { start_date:   '2005/07/18'.to_date, end_date: '2005/07/25'.to_date }
       }
 
-      it "updates the requested conference" do
-        expect(conference.start_date).to eq(valid_attributes[:start_date])
+      before do
         put :update, params: {id: conference.to_param, conference: new_attributes}
+      end
+
+      it "updates the requested conference" do
         expect(assigns(:conference).start_date).to eq(new_attributes[:start_date])
       end
 
       it "redirects to the conference" do
-        put :update, params: {id: conference.to_param, conference: valid_attributes}
         expect(response).to redirect_to(conference)
       end
     end
 
     context "with invalid params" do
-      it "assigns the conference as @conference" do
+      before do
         put :update, params: {id: conference.to_param, conference: invalid_attributes}
+      end
+
+      it "assigns the conference as @conference" do
         expect(assigns(:conference)).to eq(conference)
       end
 
       it "re-renders the 'edit' template" do
-        put :update, params: {id: conference.to_param, conference: invalid_attributes}
         expect(response).to render_template("edit")
       end
     end
   end
 
   describe "DELETE #destroy" do
-
-    let!(:conference) { Conference.create! valid_attributes }
+    before do
+      expect(conference).to be_present # in these cases, touch it in advance to create it
+    end
 
     it "destroys the requested conference" do
       # preconditions that should be satisfied by setup

--- a/spec/controllers/organizers_controller_spec.rb
+++ b/spec/controllers/organizers_controller_spec.rb
@@ -130,15 +130,28 @@ RSpec.describe OrganizersController, type: :controller do
   end
 
   describe "DELETE #destroy" do
+
+    let!(:organizer) { Organizer.create! valid_attributes }
+
     it "destroys the requested organizer" do
-      organizer = Organizer.create! valid_attributes
       expect {
         delete :destroy, params: {id: organizer.to_param}
       }.to change(Organizer, :count).by(-1)
     end
 
+    context "with an organizer owning conferences" do
+
+      let!(:conference) { create :conference, organizer_id: organizer.id }
+
+      it "does not destroy the requested conference" do
+        expect {
+          delete :destroy, params: {id: organizer.to_param}
+        }.not_to change(Organizer, :count)
+
+      end
+    end
+
     it "redirects to the organizers list" do
-      organizer = Organizer.create! valid_attributes
       delete :destroy, params: {id: organizer.to_param}
       expect(response).to redirect_to(organizers_url)
     end

--- a/spec/controllers/organizers_controller_spec.rb
+++ b/spec/controllers/organizers_controller_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe OrganizersController, type: :controller do
     { name: "" }
   }
 
+  let(:organizer) { Organizer.create! valid_attributes }
+
   setup :activate_authlogic
 
   before do
@@ -28,19 +30,14 @@ RSpec.describe OrganizersController, type: :controller do
   let(:valid_session) { {} }
 
   describe "when listing organizers" do
-    before do
-      @organizer = Organizer.create! valid_attributes
-    end
-
     it "assigns all organizers as @organizers" do
       get :index, params: {}
-      expect(assigns(:organizers)).to eq([@organizer])
+      expect(assigns(:organizers)).to eq([organizer])
     end
   end
 
   describe "GET #show" do
     it "assigns the requested organizer as @organizer" do
-      organizer = Organizer.create! valid_attributes
       get :show, params: {id: organizer.to_param}
       expect(assigns(:organizer)).to eq(organizer)
     end
@@ -55,7 +52,6 @@ RSpec.describe OrganizersController, type: :controller do
 
   describe "GET #edit" do
     it "assigns the requested organizer as @organizer" do
-      organizer = Organizer.create! valid_attributes
       get :edit, params: {id: organizer.to_param}
       expect(assigns(:organizer)).to eq(organizer)
     end
@@ -100,29 +96,31 @@ RSpec.describe OrganizersController, type: :controller do
         { name: 'Updated Title' }
       }
 
-      it "updates the requested organizer" do
-        organizer = Organizer.create! valid_attributes
-        expect(organizer.name).to eq('Valid Organizer')
+      before do
         put :update, params: {id: organizer.to_param, organizer: new_attributes}
+      end
+
+      it "updates the requested organizer" do
+        expect(organizer.name).to eq('Valid Organizer')
         expect(assigns(:organizer).name).to eq(new_attributes[:name])
       end
 
       it "redirects to the organizer" do
-        organizer = Organizer.create! valid_attributes
-        put :update, params: {id: organizer.to_param, organizer: valid_attributes}
         expect(response).to redirect_to(organizer)
       end
     end
 
     context "with invalid params" do
+      before do
+        put :update, params: {id: organizer.to_param, organizer: invalid_attributes}
+      end
+
       it "assigns the organizer as @organizer" do
-        organizer = Organizer.create! valid_attributes
         put :update, params: {id: organizer.to_param, organizer: invalid_attributes}
         expect(assigns(:organizer)).to eq(organizer)
       end
 
       it "re-renders the 'edit' template" do
-        organizer = Organizer.create! valid_attributes
         put :update, params: {id: organizer.to_param, organizer: invalid_attributes}
         expect(response).to render_template("edit")
       end
@@ -130,8 +128,9 @@ RSpec.describe OrganizersController, type: :controller do
   end
 
   describe "DELETE #destroy" do
-
-    let!(:organizer) { Organizer.create! valid_attributes }
+    before do
+      expect(organizer).to be_present # in these cases, touch it in advance to create it
+    end
 
     it "destroys the requested organizer" do
       expect {

--- a/spec/controllers/presentations_controller_spec.rb
+++ b/spec/controllers/presentations_controller_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe PresentationsController, type: :controller do
     { name: "" }
   }
 
+  let(:presentation) { Presentation.create! valid_attributes }
+
   setup :activate_authlogic
 
   before do
@@ -28,19 +30,15 @@ RSpec.describe PresentationsController, type: :controller do
   let(:valid_session) { {} }
 
   describe "when listing presentations" do
-    before do
-      @presentation = Presentation.create! valid_attributes
-    end
-
     it "assigns all presentations as @presentations" do
       get :index, params: {}
-      expect(assigns(:presentations)).to eq([@presentation])
+      expect(assigns(:presentations)).to eq([presentation])
     end
 
     context "with a search term" do
       it "finds presentations with matching titles without regard to case" do
         get :index, params:{ search_term: 'VALID' }
-        expect(assigns(:presentations)).to eq([@presentation])
+        expect(assigns(:presentations)).to eq([presentation])
       end
 
       it "it doesn't find non-matching presentations" do
@@ -52,12 +50,12 @@ RSpec.describe PresentationsController, type: :controller do
     context "with an auto-complete search term" do
       it "finds presentations with titles starting with the search term (case insensitive)" do
         get :index, params:{ q: 'VALID' }
-        expect(assigns(:presentations)).to eq([@presentation])
+        expect(assigns(:presentations)).to eq([presentation])
       end
 
       it "finds presentations with interior words starting with the search term" do
         get :index, params:{ q: 'present' }
-        expect(assigns(:presentations)).to eq([@presentation])
+        expect(assigns(:presentations)).to eq([presentation])
       end
 
       it "it doesn't find non-matching presentations" do
@@ -82,7 +80,6 @@ RSpec.describe PresentationsController, type: :controller do
 
   describe "GET #show" do
     it "assigns the requested presentation as @presentation" do
-      presentation = Presentation.create! valid_attributes
       get :show, params: {id: presentation.to_param}
       expect(assigns(:presentation)).to eq(presentation)
     end
@@ -107,7 +104,6 @@ RSpec.describe PresentationsController, type: :controller do
 
   describe "GET #edit" do
     it "assigns the requested presentation as @presentation" do
-      presentation = Presentation.create! valid_attributes
       get :edit, params: {id: presentation.to_param}
       expect(assigns(:presentation)).to eq(presentation)
     end
@@ -153,14 +149,12 @@ RSpec.describe PresentationsController, type: :controller do
       }
 
       it "updates the requested presentation" do
-        presentation = Presentation.create! valid_attributes
         expect(presentation.name).to eq('Valid Presentation')
         put :update, params: {id: presentation.to_param, presentation: new_attributes}
         expect(assigns(:presentation).name).to eq(new_attributes[:name])
       end
 
       it "redirects to the presentation" do
-        presentation = Presentation.create! valid_attributes
         put :update, params: {id: presentation.to_param, presentation: valid_attributes}
         expect(response).to redirect_to(presentation)
       end
@@ -168,13 +162,11 @@ RSpec.describe PresentationsController, type: :controller do
 
     context "with invalid params" do
       it "assigns the presentation as @presentation" do
-        presentation = Presentation.create! valid_attributes
         put :update, params: {id: presentation.to_param, presentation: invalid_attributes}
         expect(assigns(:presentation)).to eq(presentation)
       end
 
       it "re-renders the 'edit' template" do
-        presentation = Presentation.create! valid_attributes
         put :update, params: {id: presentation.to_param, presentation: invalid_attributes}
         expect(response).to render_template("edit")
       end
@@ -182,15 +174,17 @@ RSpec.describe PresentationsController, type: :controller do
   end
 
   describe "DELETE #destroy" do
+    before do
+      expect(presentation).to be_present # in these cases, touch it in advance to create it
+    end
+
     it "destroys the requested presentation" do
-      presentation = Presentation.create! valid_attributes
       expect {
         delete :destroy, params: {id: presentation.to_param}
       }.to change(Presentation, :count).by(-1)
     end
 
     it "redirects to the presentations list" do
-      presentation = Presentation.create! valid_attributes
       delete :destroy, params: {id: presentation.to_param}
       expect(response).to redirect_to(presentations_url)
     end

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe PublicationsController, type: :controller do
     { format: Publication::FORMATS.first, presentation_id: nil }
   }
 
+  let(:publication) { Publication.create! valid_attributes }
+
   before do
     pretend_to_be_authenticated
     allow(@current_user).to receive(:id).and_return 1
@@ -41,30 +43,29 @@ RSpec.describe PublicationsController, type: :controller do
         { format: Publication::FORMATS.last }
       }
 
-      it "updates the requested publication" do
-        publication = Publication.create! valid_attributes
-        expect(publication.format).to eq(valid_attributes[:format])
+      before do
         put :update, params: {id: publication.to_param, publication: new_attributes}
+      end
+
+      it "updates the requested publication" do
         expect(assigns(:publication).format).to eq(new_attributes[:format])
       end
 
       it "redirects to the manage publication page for the presentation" do
-        publication = Publication.create! valid_attributes
-        put :update, params: {id: publication.to_param, publication: valid_attributes}
         expect(response).to redirect_to manage_publications_presentation_path(publication.presentation_id)
       end
     end
 
     context "with invalid params" do
-      it "assigns the publication as @publication" do
-        publication = Publication.create! valid_attributes
+      before do
         put :update, params: {id: publication.to_param, publication: invalid_attributes}
+      end
+
+      it "assigns the publication as @publication" do
         expect(assigns(:publication)).to eq(publication)
       end
 
       it "re-renders the 'edit' template" do
-        publication = Publication.create! valid_attributes
-        put :update, params: {id: publication.to_param, publication: invalid_attributes}
         expect(response).to render_template("edit")
       end
     end
@@ -72,20 +73,19 @@ RSpec.describe PublicationsController, type: :controller do
 
   describe "DELETE #destroy" do
     before do
-      @publication = create :publication
-      delete :destroy, params: {id: @publication.to_param}
+      delete :destroy, params: {id: publication.to_param}
     end
 
     it "finds the publication" do
-      expect(assigns(:publication)).to eq(@publication)
+      expect(assigns(:publication)).to eq(publication)
     end
 
     it "destroys the publication" do
-      expect { @publication.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { publication.reload }.to raise_error ActiveRecord::RecordNotFound
     end
 
     it "redirects to the manage_publications page for the presentation" do
-      expect(response).to redirect_to manage_publications_presentation_path(@publication.presentation_id)
+      expect(response).to redirect_to manage_publications_presentation_path(publication.presentation_id)
     end
   end
 end

--- a/spec/controllers/speakers_controller_spec.rb
+++ b/spec/controllers/speakers_controller_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe SpeakersController, type: :controller do
     { name: "" }
   }
 
+  let(:speaker) { Speaker.create! valid_attributes }
+
   setup :activate_authlogic
 
   before do
@@ -28,19 +30,15 @@ RSpec.describe SpeakersController, type: :controller do
   let(:valid_session) { {} }
 
   describe "when listing speakers" do
-    before do
-      @speaker = Speaker.create! valid_attributes
-    end
-
     it "assigns all speakers as @speakers" do
       get :index, params: {}
-      expect(assigns(:speakers)).to eq([@speaker])
+      expect(assigns(:speakers)).to eq([speaker])
     end
 
     context "with a search term" do
       it "finds speakers with matching titles without regard to case" do
         get :index, params:{ search_term: 'VALID' }
-        expect(assigns(:speakers)).to eq([@speaker])
+        expect(assigns(:speakers)).to eq([speaker])
       end
 
       it "it doesn't find non-matching speakers" do
@@ -52,12 +50,12 @@ RSpec.describe SpeakersController, type: :controller do
     context "with an auto-complete search term" do
       it "finds speakers with titles starting with the search term (case insensitive)" do
         get :index, params:{ q: 'VALID' }
-        expect(assigns(:speakers)).to eq([@speaker])
+        expect(assigns(:speakers)).to eq([speaker])
       end
 
       it "finds speakers with interior words starting with the search term" do
         get :index, params:{ q: 'speaker' }
-        expect(assigns(:speakers)).to eq([@speaker])
+        expect(assigns(:speakers)).to eq([speaker])
       end
 
       it "it doesn't find non-matching speakers" do
@@ -66,7 +64,7 @@ RSpec.describe SpeakersController, type: :controller do
       end
 
       it "it doesn't find excluded speakers" do
-        get :index, params:{ q: 'valid', exclude: @speaker.id }
+        get :index, params:{ q: 'valid', exclude: speaker.id }
         expect(assigns(:speakers)).to be_empty
       end
     end
@@ -74,7 +72,6 @@ RSpec.describe SpeakersController, type: :controller do
 
   describe "GET #show" do
     it "assigns the requested speaker as @speaker" do
-      speaker = Speaker.create! valid_attributes
       get :show, params: {id: speaker.to_param}
       expect(assigns(:speaker)).to eq(speaker)
     end
@@ -89,7 +86,6 @@ RSpec.describe SpeakersController, type: :controller do
 
   describe "GET #edit" do
     it "assigns the requested speaker as @speaker" do
-      speaker = Speaker.create! valid_attributes
       get :edit, params: {id: speaker.to_param}
       expect(assigns(:speaker)).to eq(speaker)
     end
@@ -135,14 +131,12 @@ RSpec.describe SpeakersController, type: :controller do
       }
 
       it "updates the requested speaker" do
-        speaker = Speaker.create! valid_attributes
         expect(speaker.name).to eq('Valid Speaker')
         put :update, params: {id: speaker.to_param, speaker: new_attributes}
         expect(assigns(:speaker).name).to eq(new_attributes[:name])
       end
 
       it "redirects to the speaker" do
-        speaker = Speaker.create! valid_attributes
         put :update, params: {id: speaker.to_param, speaker: valid_attributes}
         expect(response).to redirect_to(speaker)
       end
@@ -150,13 +144,11 @@ RSpec.describe SpeakersController, type: :controller do
 
     context "with invalid params" do
       it "assigns the speaker as @speaker" do
-        speaker = Speaker.create! valid_attributes
         put :update, params: {id: speaker.to_param, speaker: invalid_attributes}
         expect(assigns(:speaker)).to eq(speaker)
       end
 
       it "re-renders the 'edit' template" do
-        speaker = Speaker.create! valid_attributes
         put :update, params: {id: speaker.to_param, speaker: invalid_attributes}
         expect(response).to render_template("edit")
       end
@@ -164,15 +156,17 @@ RSpec.describe SpeakersController, type: :controller do
   end
 
   describe "DELETE #destroy" do
+    before do
+      expect(speaker).to be_present # in these cases, touch it in advance to create it
+    end
+
     it "destroys the requested speaker" do
-      speaker = Speaker.create! valid_attributes
       expect {
         delete :destroy, params: {id: speaker.to_param}
       }.to change(Speaker, :count).by(-1)
     end
 
     it "redirects to the speakers list" do
-      speaker = Speaker.create! valid_attributes
       delete :destroy, params: {id: speaker.to_param}
       expect(response).to redirect_to(speakers_url)
     end

--- a/spec/controllers/speakers_controller_spec.rb
+++ b/spec/controllers/speakers_controller_spec.rb
@@ -166,6 +166,18 @@ RSpec.describe SpeakersController, type: :controller do
       }.to change(Speaker, :count).by(-1)
     end
 
+    context "with owned presentations" do
+
+      let!(:presentation) { create :presentation }
+      let!(:presentation_speaker) { create :presentation_speaker, presentation_id: presentation.id, speaker_id: speaker.id }
+
+      it "does not destroy the requested speaker" do
+        expect {
+          delete :destroy, params: {id: speaker.to_param}
+        }.not_to change(Speaker, :count)
+      end
+    end
+
     it "redirects to the speakers list" do
       delete :destroy, params: {id: speaker.to_param}
       expect(response).to redirect_to(speakers_url)

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Conference, type: :model do
-  def valid_attributes
-    {
-      :organizer_id => 1,
-      :start_date   => '2005/07/15'.to_date,
-      :end_date     => '2005/07/23'.to_date
-    }
-  end
+  describe "when creating a conference" do
 
-  describe "when creating a Conference" do
+    let(:valid_attributes) {
+      {
+        :organizer_id => 1,
+        :start_date   => '2005/07/15'.to_date,
+        :end_date     => '2005/07/23'.to_date
+      }
+    }
+
     it "should have a working factory" do
       expect(create :conference).to be_valid
     end
@@ -29,5 +30,36 @@ RSpec.describe Conference, type: :model do
     it "should be invalid without end_date" do
       expect(Conference.new(valid_attributes.merge(end_date: nil))).not_to be_valid
     end
+  end
+
+  describe "when destroying a conference" do
+    let(:conference) { create :conference }
+
+    # Currently, conferences with presentations can't be destroyed - the presentations have to be
+    # deleted or unlinked individually.
+    # context "with presentations" do
+    #   let!(:presentation) { create :presentation, conference_id: conference.id }
+    #
+    #   it "also destroys the presentations" do
+    #     conference.destroy
+    #     expect{ presentation.reload }.to raise_error ActiveRecord::RecordNotFound
+    #   end
+    # end
+
+    context "with users" do
+      let!(:user) { create :user }
+      let!(:conference_user) { create :conference_user, conference_id: conference.id, user_id: user.id }
+
+      it "also destroys the conference/user relationship" do
+        conference.destroy
+        expect{ conference_user.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it "does not destroy the user" do
+        conference.destroy
+        expect(user.reload).to eq(user)
+      end
+    end
+
   end
 end

--- a/spec/models/conference_user_spec.rb
+++ b/spec/models/conference_user_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe ConferenceUser, type: :model do
-  def valid_attributes
-    {
-      :conference_id => 1,
-      :user_id => 1,
-      :creator_id => 1
-    }
-  end
-
   describe "when creating a Conference User" do
+
+    let(:valid_attributes) {
+      {
+        :conference_id => 1,
+        :user_id => 1,
+        :creator_id => 1
+      }
+    }
+
     it "should have a working factory" do
       expect(create :conference_user).to be_valid
     end

--- a/spec/models/organizer_spec.rb
+++ b/spec/models/organizer_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Organizer, type: :model do
-  def valid_attributes
-    {
-      name: "Valid Organizer"
-    }
-  end
-
   describe "when creating a Organizer" do
+
+    let(:valid_attributes) {
+      { name: "Valid Organizer" }
+    }
+
     it "should have a working factory" do
       expect(create :organizer).to be_valid
     end

--- a/spec/models/presentation_speaker_spec.rb
+++ b/spec/models/presentation_speaker_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe PresentationSpeaker, type: :model do
-  def valid_attributes
-    {
-      :presentation_id => 1,
-      :speaker_id => 1,
-      :creator_id => 1
-    }
-  end
-
   describe "when creating a Conference" do
+
+    let(:valid_attributes) {
+      {
+        :presentation_id  => 1,
+        :speaker_id       => 1,
+        :creator_id       => 1
+      }
+    }
+
     it "should have a working factory" do
       expect(create :presentation_speaker).to be_valid
     end

--- a/spec/models/presentation_spec.rb
+++ b/spec/models/presentation_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Presentation, type: :model do
-  def valid_attributes
-    {
-      name: "Valid Presentation"
-    }
-  end
-
   describe "when creating a Presentation" do
+    let(:valid_attributes) {
+      { name: "Valid Presentation" }
+    }
+
     it "should have a working factory" do
       expect(create :presentation).to be_valid
     end
@@ -18,6 +16,35 @@ RSpec.describe Presentation, type: :model do
 
     it "requires a name" do
       expect(Presentation.new(valid_attributes.merge(name: ''))).not_to be_valid
+    end
+  end
+
+  describe "when destroying a Presentation" do
+
+    let(:presentation) { create :presentation }
+
+    context "with publications" do
+      let!(:publication) { create :publication, presentation_id: presentation.id }
+
+      it "also destroys the publications" do
+        presentation.destroy
+        expect{ publication.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "with speakers" do
+      let!(:speaker) { create :speaker }
+      let!(:presentation_speaker) { create :presentation_speaker, presentation_id: presentation.id, speaker_id: speaker.id }
+
+      it "also destroys the presentation/speaker relationship" do
+        presentation.destroy
+        expect{ presentation_speaker.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it "does not destroy the speaker" do
+        presentation.destroy
+        expect(speaker.reload).to eq(speaker)
+      end
     end
   end
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Publication, type: :model do
-  def valid_attributes
-    {
-      :presentation_id => 1,
-      :format => Publication::CD
-    }
-  end
-
   describe "when creating a Publication" do
+
+    let(:valid_attributes) {
+      {
+        :presentation_id => 1,
+        :format => Publication::CD
+      }
+    }
+
     it "should have a working factory" do
       expect(create :publication).to be_valid
     end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 RSpec.describe Role, :type => :model do
   fixtures :roles
 
-  def valid_attributes
-    {
-      :name => Role::ADMIN
-    }
-  end
-
   describe "when creating a Role" do
+
+    let(:valid_attributes) {
+      { :name => Role::ADMIN }
+    }
+
     it "should have a working factory" do
       expect(create :role).to be_valid
     end

--- a/spec/models/speaker_spec.rb
+++ b/spec/models/speaker_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Speaker, type: :model do
-  def valid_attributes
-    {
-      name: "Testing Userperson"
-    }
-  end
-
   describe "when creating a Speaker" do
+
+    let(:valid_attributes) {
+      { name: "Testing Userperson" }
+    }
+
     it "should have a working factory" do
       expect(create :speaker).to be_valid
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,19 +3,20 @@ require 'rails_helper'
 RSpec.describe User, :type => :model do
 
   describe "when creating a User" do
-    before do
-      @role = create :role
-      @valid_attributes =  {
+
+    let(:role) { create :role }
+    let(:valid_attributes) {
+      {
         :name     => 'Generic User',
         :email    => 'testing@example.com',
         :password => 'password1',
         :password_confirmation => 'password1',
-        :role     =>  @role
+        :role     =>  role
       }
-    end
+    }
 
     it "should be valid with valid attributes" do
-      expect(User.new(@valid_attributes)).to be_valid
+      expect(User.new(valid_attributes)).to be_valid
     end
 
     it "should have a working factory" do
@@ -23,25 +24,25 @@ RSpec.describe User, :type => :model do
     end
 
     it "should require a name" do
-      expect { User.create! @valid_attributes.merge(name: '') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+      expect { User.create! valid_attributes.merge(name: '') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
     end
 
     it "should require an email" do
-      expect { User.create! @valid_attributes.merge(email: '') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email should look like an email address.")
+      expect { User.create! valid_attributes.merge(email: '') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email should look like an email address.")
     end
 
     it "cleans the email" do
-      user = User.new(@valid_attributes.merge(email: ' bob@example.com '))
+      user = User.new(valid_attributes.merge(email: ' bob@example.com '))
       user.valid?
       expect(user.email).to eq('bob@example.com')
     end
 
     it "should require a plausible email" do
-      expect { User.create! @valid_attributes.merge(email: 'bipity.bop') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email should look like an email address.")
+      expect { User.create! valid_attributes.merge(email: 'bipity.bop') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email should look like an email address.")
     end
 
     it "should require matching password and confirmation" do
-      expect { User.create! @valid_attributes.merge(password: 'bogus', password_confirmation: 'bogosity') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Password is too short (minimum is 7 characters), Password confirmation doesn't match Password")
+      expect { User.create! valid_attributes.merge(password: 'bogus', password_confirmation: 'bogosity') }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Password is too short (minimum is 7 characters), Password confirmation doesn't match Password")
     end
 
     it "should require a role" do
@@ -59,5 +60,28 @@ RSpec.describe User, :type => :model do
         expect(User.needing_approval).to eq([@user])
       end
     end
+  end
+
+  describe "when destroying a user" do
+
+    let(:user) { create :user }
+
+    it "handles references to the user as creator"
+
+    context "with conferences" do
+      let!(:conference) { create :conference }
+      let!(:conference_user) { create :conference_user, conference_id: conference.id, user_id: user.id }
+
+      it "also destroys the conference/user relationship" do
+        user.destroy
+        expect{ conference_user.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it "does not destroy the conference" do
+        user.destroy
+        expect(conference.reload).to eq(conference)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixes issue #24 (add program URL to conferences)
**Also**: controller spec cleanup, handling of cascading in deletions, don't delete conferences, speakers, or organizers when they have data. Add the ability to easily search for online instances of a presentation. 