### PR TITLE
Release v036

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -66,14 +66,14 @@ class PublicationsController < ApplicationController
   end
 
   def edit
+    @publication.name ||= @presentation.name if @presentation.present?
   end
 
   def update
     # Backfill these values on legacy presentations
-    if @presentation.present?
-      @publication.name ||= @presentation.name
-      @publication.speaker_names ||= 'N/A'        # something meaningful to show Editors when looking at publication details regular users can't see
-    end
+    @publication.name ||= @presentation&.name || 'N/A'
+    @publication.speaker_names ||= 'N/A'        # something meaningful to show Editors when looking at publication details regular users can't see
+
     if @publication.update_attributes publication_params
       if @presentation.present?
         if params[:canonical].present? # then update this attribute of the relationship

--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -1,7 +1,15 @@
 module PublicationsHelper
 
+  # Gets an HTML listing of the publications conference names, with canonical ones marked with an icon
   def conference_names(publication)
-    publication.presentations.collect{|p| truncate(p.conference&.name, length: 40) }.join('<br/>').html_safe
+    names = []
+    publication.presentation_publications.each do |presentation_publication|
+      name = ''
+      name += icon('fas', 'crown', :class => 'fa-fw text-warning') + '&nbsp'.html_safe if presentation_publication.canonical
+      name += truncate(presentation_publication.presentation.conference_name, length: 40)
+      names << name
+    end
+    names.join('<br/>').html_safe
   end
 
   def format_and_date(publication)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -20,7 +20,14 @@ class Conference < ApplicationRecord
   before_save       :update_default_name
 
   extend FriendlyId
-  friendly_id :name, use: [:slugged, :history]
+  friendly_id :slug_candidates, use: [:slugged, :history]
+
+  def slug_candidates
+    [
+      :name,
+      [:name, :city]
+    ]
+  end
 
   # This is necessary to make Friendly_id generate a new slug when the current name is changed.
   def should_generate_new_friendly_id?

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -18,10 +18,18 @@ class Presentation < ApplicationRecord
 
   acts_as_taggable
 
-  extend FriendlyId
-  friendly_id :name, use: [:slugged, :history]
-
   mount_uploader :handout, DocumentUploader
+
+  extend FriendlyId
+  friendly_id :slug_candidates, use: [:slugged, :history]
+
+  # This won't work for standalone presentations, but there isn't anything else meaningful.
+  def slug_candidates
+    [
+      :name,
+      [:name, :conference_name]
+    ]
+  end
 
   # This is necessary to make Friendly_id generate a new slug when the current name is changed.
   def should_generate_new_friendly_id?

--- a/app/views/presentations/_publication.html.haml
+++ b/app/views/presentations/_publication.html.haml
@@ -4,3 +4,6 @@
   = " - #{ publication.duration } mins"
 - if publication.notes.present?
   = " - #{ publication.notes }"
+
+- if can? :edit, publication
+  = link_to icon('fas', 'eye', class: 'fa-sm'), publication_path(publication)

--- a/app/views/presentations/show.html.haml
+++ b/app/views/presentations/show.html.haml
@@ -36,7 +36,8 @@
             = icon('fas', 'crown', :class => 'fa-fw text-warning') if presentation_publication.canonical
             = render :partial => 'publication', locals: { publication: publication }
 
-      %p= link_to icon('fas', 'search', 'Search for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
+      - if can?(:edit, @presentation)
+        %p= link_to icon('fas', 'search', 'Search for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
 
 - if can?(:edit, @presentation) && @presentation.editors_notes.present?
   .row

--- a/app/views/presentations/show.html.haml
+++ b/app/views/presentations/show.html.haml
@@ -39,7 +39,7 @@
       - if can?(:edit, @presentation)
         %p= link_to icon('fas', 'search', 'Search for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
 
-- if can?(:edit, @presentation) && @presentation.editors_notes.present?
+- if can?(:edit, @presentation) # && @presentation.editors_notes.present?
   .row
     .col-md-12
       %p

--- a/app/views/publications/_form_fields.html.haml
+++ b/app/views/publications/_form_fields.html.haml
@@ -10,7 +10,8 @@
 - if @publication.presentations.empty?
   .row
     .col-md-12
-      = f.input :speaker_names, hint: 'Last names separated by commas - used to find the right presentation'
+      = f.input :speaker_names, hint: 'Free text names - helpful later to find the matching presentation.'
+
 .row
   .col-md-2
     -# @presentation has to be here explicitly because we never let publications exist standalone

--- a/app/views/publications/_form_fields.html.haml
+++ b/app/views/publications/_form_fields.html.haml
@@ -1,8 +1,13 @@
-- if @publication.presentations.empty? && action_name != 'manage_publications'
-  -# These fields matter only for orphan publications in order to later find and attach them to the right presentations
+-# Name and Speaker Names matter only for orphan publications in order to later find and attach them to the right presentations.
+-# Name remains editable however, because it is still shown in the publications listing.
+- if @publication.presentations.empty? || controller_name == 'publications'
   .row
     .col-md-12
-      = f.input :name, input_html: { value: @publication.name || @presentation&.name }
+      - hint_text = @publication.presentations.empty? ? 'Match the presentation name, if known, to make association easier' : 'Only Editors see this name in Publications listing'
+      = f.input :name, input_html: { value: @publication.name || @presentation&.name }, hint: hint_text
+-# Once the publication is associated with a presentation, the speaker_names field is totally irrelevant.
+-# The controller ensures that it isn't blank when it's being hidden.
+- if @publication.presentations.empty?
   .row
     .col-md-12
       = f.input :speaker_names, hint: 'Last names separated by commas - used to find the right presentation'

--- a/app/views/publications/edit.html.haml
+++ b/app/views/publications/edit.html.haml
@@ -1,3 +1,15 @@
+.row
+  .col-md-12
+    - if @publication.presentations.blank?
+      = title 'Editing Unassociated Publication'
+      %h5 Name and Speaker Names may be helpful in finding the presentaiton later.
+    - else
+      %h4
+        Publication of:
+        = @publication.presentations.first.name
+        - if @publication.presentations.length > 1
+          '(and others)'
+
 -# The publications form_fields partial does its own column management
 = simple_form_for @publication, :html => {:autocomplete => "off"} do |f|
   = render :partial => "form_fields", :locals => {:f => f}

--- a/app/views/publications/show.html.haml
+++ b/app/views/publications/show.html.haml
@@ -19,9 +19,12 @@
           %i unspecified
     %p
       %b Notes
-      = @publication.notes
+      - if @publication.notes.present?
+        = @publication.notes
+      - else
+        %i none
 
-- if can?(:edit, @publication) && @publication.editors_notes.present?
+- if can?(:edit, @publication)
   .row
     .col-md-12
       %p


### PR DESCRIPTION
Fixes some minor bugs in publication edit re when to show name and speaker names. Also adds some fallbacks for friendly ID slugs to help avoid GUIDs in URLs.