### PR TITLE
Release v085

### DIFF
--- a/app/controllers/concerns/publications_chart.rb
+++ b/app/controllers/concerns/publications_chart.rb
@@ -44,16 +44,12 @@ module PublicationsChart
   def publication_year_count_data
     # There is no user-specific publication listing comparable to "My Events" (yet)
     if param_context(:search_term).present? || param_context(:tag).present? || param_context(:event_type).present?
-      # We can't set a limit via having here, because the interesting results might be in the 1-2 range.
-      # Just have to let the results fly, and hope it's not too huge.
-      query = init_query(Publication) # we can't pre-build the query, but starting with nothing works
+      # Build a query using the current search term and tag
       query = base_query(query)
       results = Publication.group_by_year("publications.published_on").where(query.where_clause, *query.bindings).count
 
     else
-      # Show the top countries - otherwise it's too big - limit is not great here, because even though results are sorted
-      # by count, limit might cut off countries with the same count as countries shown, which is misleading. There is a setting
-      # for the speaker chart floor - but not for countries (yet) - 2 works well.
+      # Get everything
       results = Publication.group_by_year("publications.published_on").count
     end
 
@@ -61,4 +57,20 @@ module PublicationsChart
     return results.inject({}) { |h, (k, v)| h.merge( (k.is_a?(Date) ? k.year : k) => v) }
   end
 
+  def publication_duration_year_count_data
+    # There is no user-specific publication listing comparable to "My Events" (yet)
+    if param_context(:search_term).present? || param_context(:tag).present? || param_context(:event_type).present?
+      # Build a query using the current search term and tag
+      query = init_query(Publication) # we can't pre-build the query, but starting with nothing works
+      query = base_query(query)
+      results = Publication.group_by_year("publications.published_on").where(query.where_clause, *query.bindings).count
+
+    else
+      # Get everything
+      results = Publication.group_by_year("publications.published_on").sum('duration')
+    end
+
+    # group_by_year groups by Jan 1 of each year - we want to see only the year - duration is in minutes - make it hours
+    return results.inject({}) { |h, (k, v)| h.merge( (k.is_a?(Date) ? k.year : k) => v / 60 ) }
+  end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -72,6 +72,9 @@ class PublicationsController < ApplicationController
     when 'year' then
       @publications = publication_year_count_data.to_a
       render 'years_chart'
+    when 'duration_year' then
+      @publications = publication_duration_year_count_data.to_a
+      render 'duration_by_year_chart'
     else
       flash[:error] = 'Unknown chart type'
       redirect_to publications_path

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -5,7 +5,8 @@ class SettingsController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @setting = Setting.first
+    # Get all the settings directly in the view from the class methods, as it would be used in the code
+    @setting = Setting.first  # the edit button uses this
   end
 
   def edit
@@ -25,6 +26,6 @@ class SettingsController < ApplicationController
   private
 
   def setting_params
-    params.require(:setting).permit(:require_account_approval, :speaker_chart_floor, :api_open, :facebook_sharing)
+    params.require(:setting).permit(:require_account_approval, :speaker_chart_floor, :api_open, :facebook_sharing, :base_event_year)
   end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -52,7 +52,9 @@ class Publication < ApplicationRecord
       if ui_duration == 'N/A'
         self.duration = nil
         self.ui_duration = ''
-      elsif ui_duration&.include?(':')
+      elsif ui_duration.tr('0-9', '').length > 0        # expect there is some delimiter
+        delimiter = ui_duration.tr('0-9', '').first     # the typo for colon has to be consistent, 01;18/05 will fail
+        ui_duration.gsub!(delimiter, ':')               # whatever the non-digit was, make it a colon
         self.duration =  unformatted_time(ui_duration)  # expect hh:mm or hh:mm:ss format
       else
         self.duration = ui_duration.to_i                # expect raw minutes format

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -20,6 +20,11 @@ class Setting < ApplicationRecord
     return @setting.facebook_sharing
   end
 
+  def self.base_event_year
+    get_settings
+    return @setting.base_event_year || 1959
+  end
+
   private
 
   def self.get_settings

--- a/app/views/events/_form_fields.html.haml
+++ b/app/views/events/_form_fields.html.haml
@@ -2,8 +2,8 @@
 -# can get a sensible name, and the friendly URL will be based on that name.
 = f.input :organizer_id, as: 'select', collection: @organizer_selections, include_blank: false
 = f.input :event_type, as: :select, collection: Conference::EVENT_TYPES, include_blank: false
-= f.input :start_date, as: :date, start_year: 1959, end_year: Date.today.year + 1, order: [:month, :day, :year]
-= f.input :end_date, as: :date, start_year: 1959, end_year: Date.today.year + 1, order: [:month, :day, :year]
+= f.input :start_date, as: :date, start_year: Setting.base_event_year, end_year: Date.today.year + 1, order: [:month, :day, :year]
+= f.input :end_date, as: :date, start_year: Setting.base_event_year, end_year: Date.today.year + 1, order: [:month, :day, :year]
 - if name_blank_or_default?(@conference)
   - hint = "Don't change this unless absolutely necessary for clarity (e.g. special events) -  AUTO-UPDATING"
 - else

--- a/app/views/presentations/_base_form_fields.html.haml
+++ b/app/views/presentations/_base_form_fields.html.haml
@@ -14,7 +14,7 @@
 = f.input :handout, label: @presentation.handout.present? ? 'Change handout' : 'Add handout'
 - if @presentation.handout.present?
   = f.input :remove_handout, as: :boolean
-= f.input :date, as: :date, start_year: 1959, end_year: Date.today.year + 1, order: [:month, :day, :year]
+= f.input :date, as: :date, start_year: Setting.base_event_year, end_year: Date.today.year + 1, order: [:month, :day, :year]
 -# Don't show Venue unless the presentation is attached to a multi-venue event
 - if @presentation.try(:conference).try(:multi_venue?)
   = render partial: 'shared/location', locals:  {f: f, venue_type: @presentation.venue}

--- a/app/views/publications/_control_bar.html.haml
+++ b/app/views/publications/_control_bar.html.haml
@@ -29,7 +29,8 @@
             .dropdown-menu{'aria-labelledby' => "navbarDropdownMenuLink"}
               = link_to icon('fas', 'chart-bar', 'by Format',  class: 'fa-sm'), chart_publications_path(chart_type: 'format'), class: "dropdown-item"
               = link_to icon('fas', 'chart-bar', 'by Year',  class: 'fa-sm'), chart_publications_path(chart_type: 'year'), class: "dropdown-item"
-              =# link_to icon('fas', 'chart-bar', 'Speakers', class: 'fa-sm'), chart_speakers_path(chart_type: ''), class: "dropdown-item"
+              = link_to icon('fas', 'chart-bar', 'Duration by Year', class: 'fa-sm'), chart_publications_path(chart_type: 'duration_year'), class: "dropdown-item"
+              =# link_to icon('fas', 'chart-bar', 'Speakers', class: 'fa-sm'), chart_speakers_path(chart_type: 'speaker'), class: "dropdown-item"
 
         -# action-specific buttons or search form
         - if action_name == 'show'

--- a/app/views/publications/_form_fields.html.haml
+++ b/app/views/publications/_form_fields.html.haml
@@ -17,7 +17,7 @@
     -# @presentation has to be here explicitly because we never let publications exist standalone
     = f.input :format, collection: Publication::FORMATS, include_blank: false
   .col-md-2
-    = f.input :published_on, as: :date, start_year: Date.today.year, end_year: 1959,  order: [:year], include_blank: true, label: "Published"
+    = f.input :published_on, as: :date, start_year: Date.today.year, end_year: Setting.base_event_year,  order: [:year], include_blank: true, label: "Published"
   .col-md-8
     = f.input :url, label: 'URL'
     = hidden_field_tag :presentation_id, @presentation.id if @presentation.present?

--- a/app/views/publications/duration_by_year_chart.html.haml
+++ b/app/views/publications/duration_by_year_chart.html.haml
@@ -1,0 +1,15 @@
+= render partial: 'control_bar'
+
+.row.chart-controls
+  .col-md-12
+    = link_to "Done", publications_path, :class => "btn btn-sm btn-secondary float-right"
+
+    - if param_context(:search_term).present? || param_context(:tag).present?
+      = title chart_title_with_context('Publication Duration for')
+
+    - else
+      = title "Publication Duration (hours) by Year"
+
+    %p Click a year to see its publications
+    #duration_by_year_chart
+      = render partial: 'shared/publications_chart'

--- a/app/views/settings/_form_fields.html.haml
+++ b/app/views/settings/_form_fields.html.haml
@@ -3,3 +3,4 @@
   = f.input :speaker_chart_floor, :hint => 'Minimum number of presentations required to show up on the Top Speakers chart.'
   = f.input :api_open, as: :boolean, label: 'API Open', :hint => 'When false, all API update access is blocked.'
   = f.input :facebook_sharing, as: :boolean, label: 'Facebook Sharing', :hint => 'When false, the Facebook Share button is hidden.'
+  = f.input :base_event_year, as: :integer, label: 'Base Event Year', :hint => 'The earliest year for event start/end years'

--- a/app/views/settings/index.html.haml
+++ b/app/views/settings/index.html.haml
@@ -10,16 +10,21 @@
     %table.table
       %tr
         %th{width: '50%'} Require Account Approval
-        %td= humanize_boolean @setting.require_account_approval?
+        %td= humanize_boolean Setting.require_account_approval?
       %tr
         %th{width: '50%'} Top Speakers Floor
-        %td= @setting.speaker_chart_floor
+        %td= Setting.speaker_chart_floor
       %tr
         %th{width: '50%'} API Open
-        %td= @setting.api_open ? 'True' : 'False'
+        %td= Setting.api_open? ? 'True' : 'False'
       %tr
         %th{width: '50%'} Facebook Sharing Button
-        %td= @setting.facebook_sharing ? 'Available' : 'Hidden'
+        %td= Setting.facebook_sharing? ? 'Available' : 'Hidden'
+      %tr
+        %th{width: '50%'} Base Event Year
+        %td
+          = Setting.base_event_year
+          = '(default)' if @setting.base_event_year.blank?
 .row
   .col-md-12
     %p

--- a/app/views/speakers/_form_fields.html.haml
+++ b/app/views/speakers/_form_fields.html.haml
@@ -20,4 +20,4 @@
 = f.input :bio_url, label: 'Bio URL', hint: "URL for the speaker's own page, e.g. at ARI Campus or their personal site."
 = f.label 'Brief Bio'
 = f.trix_editor :description
-= f.input :bio_on, as: :date, start_year: Date.today.year, end_year: 1959,  order: [:year], include_blank: true, label: 'Date of bio info'
+= f.input :bio_on, as: :date, start_year: Date.today.year, end_year: Setting.base_event_year,  order: [:year], include_blank: true, label: 'Date of bio info'

--- a/db/migrate/20200116164824_add_base_event_year_to_settings.rb
+++ b/db/migrate/20200116164824_add_base_event_year_to_settings.rb
@@ -1,0 +1,5 @@
+class AddBaseEventYearToSettings < ActiveRecord::Migration[5.2]
+  def change
+    add_column "settings", :base_event_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_14_202257) do
+ActiveRecord::Schema.define(version: 2020_01_16_164824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_202257) do
     t.integer "speaker_chart_floor"
     t.boolean "api_open"
     t.boolean "facebook_sharing"
+    t.integer "base_event_year"
   end
 
   create_table "speakers", force: :cascade do |t|

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Publication, type: :model do
         end
       end
 
-      { '18:20': 1100, '8:20': 500, '90': 90, '1:18:20': 78, '01:18:20': 78, '4700': 4700 }.each do |hms, minutes|
+      { '18:20': 1100, '8:20': 500, '8/20': 500, '90': 90, '1:18:20': 78, '01:18:20': 78, '01;18;20': 78, '4700': 4700 }.each do |hms, minutes|
         context "from UI as #{hms}" do
           let(:valid_user_attributes) { valid_attributes.merge(ui_duration: hms.to_s)}
 

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Speaker, type: :model do
+
+  context "when getting settings for" do
+
+    # Most of these don't do anything with the value, so it's not necessary to spec them
+    describe "base event year" do
+      it "gets the default" do
+        expect(Setting.base_event_year).to eq(1959)
+      end
+
+      context "with a setting" do
+        before do
+          setting = Setting.first
+          setting.update base_event_year: 1952
+        end
+
+        it "gets the setting value" do
+          expect(Setting.base_event_year).to eq(1952)
+        end
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
Adds:
 - publication duration chart
 - tolerance for separators other than colon in hh:mm durations
 - Change base event year to a setting

Contains a migration
Requires setting the base year in settings (currently should be 1958)