### PR TITLE
Release v089

### DIFF
--- a/app/controllers/concerns/shared_queries.rb
+++ b/app/controllers/concerns/shared_queries.rb
@@ -78,7 +78,7 @@ module SharedQueries
     # We combine these to get a broad search - the search term gets initialized with the tag to catch obvious matches lacking an explicit tag.
     # ActiveRecord .or() is weird, so we build an entire query different ways depending on whether term/tag are present.
 
-    use_tag = false if collection.try(:klass).try(:name) == 'Presentation' # only presentations have tags
+    use_tag = false unless collection.try(:klass).try(:name) == 'Presentation' # only presentations have tags
 
     # These can be overridden so aggregate queries can ignore them
     term = use_term && param_context(:search_term).present? ? param_context(:search_term).split(' ').map{|s| s.strip}.compact.join(' ') : nil

--- a/app/controllers/concerns/shared_queries.rb
+++ b/app/controllers/concerns/shared_queries.rb
@@ -78,6 +78,8 @@ module SharedQueries
     # We combine these to get a broad search - the search term gets initialized with the tag to catch obvious matches lacking an explicit tag.
     # ActiveRecord .or() is weird, so we build an entire query different ways depending on whether term/tag are present.
 
+    use_tag = false if collection.try(:klass).try(:name) == 'Presentation' # only presentations have tags
+
     # These can be overridden so aggregate queries can ignore them
     term = use_term && param_context(:search_term).present? ? param_context(:search_term).split(' ').map{|s| s.strip}.compact.join(' ') : nil
     tag  = use_tag  ? param_context(:tag)&.strip : nil
@@ -86,15 +88,14 @@ module SharedQueries
       # set the search term to the tag
       term =  escape_wildcards(param_context(:tag))
       set_param_context :search_term, term
-    elsif tag.blank? && collection.try(:klass).try(:name) == 'Presentation' # only presentations have tags
+    elsif tag.blank? && use_tag
       # if the search term exists as a tag and something public is tagged with it, then set it
       if Presentation.tagged_with(term).count > 0
         tag = param_context(:search_term)
         set_param_context :tag, tag
       end
     end
-    logger.debug "Term: #{ term }    Tag: #{ tag }"
-
+    logger.debug "Initializing Query with term: '#{ term }' and tag: '#{ tag }'"
     Query.new collection, term, tag
   end
 
@@ -103,7 +104,8 @@ module SharedQueries
   # Terms:  name, city, country, year, organizer_abbreviation
 
   def base_query(query)
-    publication_query = query.collection.try(:klass).try(:name) == 'Publication' || query.collection.try(:name) == 'Publication'
+    publication_query = collection_has?(query, 'Publication')
+    speaker_query     = collection_has?(query, 'Speaker') || collection_has?(query, 'PresentationSpeaker')
 
     logger.debug "Publication query: #{publication_query}   (#{query.collection.try(:klass).try(:name)})"
     if param_context(:event_type).present? && !publication_query
@@ -111,8 +113,8 @@ module SharedQueries
     end
 
     if query.term.present?
-      # None of this stuff applies to publications
-      unless publication_query
+      # None of this stuff applies to publications or speakers
+      unless publication_query || speaker_query
         # Certain special-case terms need to override other optional searches - e.g. if we're looking for country = 'SE,
         # then we can't also say AND (conference.title ILIKE 'SE')
         if country_code(query.term.upcase)
@@ -143,7 +145,7 @@ module SharedQueries
       unless query.skip_optionals?
         if publication_query
           query.add :optional, "publications.name ILIKE ?", "%#{query.term}%"
-        else
+        elsif !speaker_query
           query.add :optional, "conferences.name ILIKE ?", "%#{query.term}%"
           query.add :optional, "conferences.city ILIKE ?", "#{query.term}%"
         end
@@ -182,7 +184,7 @@ module SharedQueries
 
   def speaker_query(query)
     if query.term.present? && !query.skip_optionals?
-      query.add :optional, 'presentations.name ILIKE ?', "%#{query.term}%"
+      #query.add :optional, 'presentations.name ILIKE ?', "%#{query.term}%"
       query.add :optional, 'speakers.name ILIKE ?', "#{query.term}%"
       query.add :optional, 'speakers.sortable_name ILIKE ?', "#{query.term}%"
     end
@@ -225,6 +227,11 @@ SELECT conference_id FROM conference_users, conferences
   end
 
   private
+
+  # look for a class in the query base - this is how the query is adjusted based on what's being searched
+  def collection_has?(query, class_name)
+    query.collection.try(:klass).try(:name) == class_name || query.collection.try(:name) == class_name
+  end
 
   # When the tag is used as a wildcard search in the remark space, any wildcard characters needs to be escaped.
   # Wildcards in the search text are allowed, but cause spurious results in tags - e.g. the dot in "this vs. that"

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -47,7 +47,7 @@ class PresentationsController < ApplicationController
         if params[:q].present?
           # generate a specific format for select2
           # TODO set up page-specific options for select2,so it can use the generic JSON
-          render json: { total: @presentations.length, users: @presentations.map{|s| {id: s.id, text: s.name } } }
+          render json: { total: @presentations.length, users: @presentations.map{|s| {id: s.id, text: "#{s.name} (#{ s.date.year })" } } }
         else
           # generate a generic API-like JSON response
           render json: PresentationSerializer.new(@presentations).serialized_json

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -173,6 +173,6 @@ class PublicationsController < ApplicationController
   end
 
   def publication_params
-    params.require(:publication).permit(:name, :speaker_names, :published_on, :format, :url, :duration, :ui_duration, :notes, :editors_notes)
+    params.require(:publication).permit(:name, :speaker_names, :published_on, :format, :url, :duration, :ui_duration, :details, :notes, :editors_notes)
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -173,6 +173,6 @@ class PublicationsController < ApplicationController
   end
 
   def publication_params
-    params.require(:publication).permit(:name, :speaker_names, :published_on, :format, :url, :duration, :ui_duration, :details, :notes, :editors_notes)
+    params.require(:publication).permit(:name, :speaker_names, :published_on, :format, :url, :duration, :ui_duration, :ari_inventory, :details, :notes, :editors_notes)
   end
 end

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -51,7 +51,7 @@ class SpeakersController < ApplicationController
     # a vertical bar chart).
     case param_context(:chart_type)
     when 'presentations' then
-      @presentations = presentation_count_data.to_a    # build the data here, or pull it from an endpoint in the JS, but not both
+      @presentations = speaker_presentation_count_data.to_a    # build the data here, or pull it from an endpoint in the JS, but not both
       render 'presentations_chart'
     when 'conferences' then
       @conferences = conference_count_data.to_a

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -1,6 +1,6 @@
 class SpeakersController < ApplicationController
 
-  include PresentationsChart    # defines the filter methods for presentations
+  include PresentationsChart    # defines the filter methods for presentations used when listing speaker presentations
   include Sortability
   include SpeakersChart
   include StickyNavigation

--- a/app/helpers/programs_helper.rb
+++ b/app/helpers/programs_helper.rb
@@ -1,2 +1,12 @@
 module ProgramsHelper
+
+  # Options:  :link_classes,
+  def linked_icon_for_program(program, options={})
+    if program.url.present?
+      link_to icon('far', 'external-link-alt', class: 'fa-fw'), program.url, target: '_blank', title: program.name, class: options[:link_classes]
+    else
+      link_to icon('far', 'file-pdf', class: 'fa-fw'), download_event_program_path(program.conference, program), target: '_blank', title: program.name, class: options[:link_classes]
+    end
+  end
+
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -20,7 +20,8 @@ class Conference < ApplicationRecord
   INTERVIEW  = 'Interview'.freeze
   SERIES     = 'Series'.freeze
   SPEECH     = 'Speech'.freeze
-  EVENT_TYPES = [CONFERENCE, DEBATE, INTERVIEW, SERIES, SPEECH, ].freeze
+  TOUR       = 'Tour'.freeze
+  EVENT_TYPES = [CONFERENCE, DEBATE, INTERVIEW, SERIES, SPEECH, TOUR].freeze
 
   validates :event_type, inclusion: { in: EVENT_TYPES, message: "%{value} is not a recognized event type" }
   validates :name, :organizer_id, :start_date, :end_date, presence: true

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,15 +9,15 @@ class Document < ApplicationRecord
   before_save  :initialize_values
   before_destroy :destroy_uploader
 
-  QUEUED  = 'queued'
-  WORKING  = 'working'
-  COMPLETE = 'complete'
-  FAILED   = 'failed'
-  STATUS_VALUES = [ QUEUED, WORKING, COMPLETE, FAILED ]
+  QUEUED  = 'queued'.freeze
+  WORKING  = 'working'.freeze
+  COMPLETE = 'complete'.freeze
+  FAILED   = 'failed'.freeze
+  STATUS_VALUES = [ QUEUED, WORKING, COMPLETE, FAILED ].freeze
 
-  PDF = 'PDF'
-  CSV = 'CSV'
-  FORMATS = [PDF, CSV]
+  PDF = 'PDF'.freeze
+  CSV = 'CSV'.freeze
+  FORMATS = [PDF, CSV].freeze
 
   def initialize_values
     self.status = QUEUED

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -13,23 +13,23 @@ class Publication < ApplicationRecord
   # Publication doesn't use friendly ID because only editors and admin can see these paths, so they aren't indexed by search engines
 
   # These are just short word strings and not icons because there aren't good icons for making things like DVD and CD distinct.
-  TAPE    = 'Tape'
-  CD      = 'CD'
-  VHS     = 'VHS'
-  DISK    = 'DVD/Blu-ray'
-  CAMPUS  = 'Campus'
-  YOUTUBE = 'YouTube'      # Is it helpful to make this distinct?
-  FACEBOOK = 'FaceBook'    # Is it helpful to make this distinct?
-  PODCAST = 'Podcast'
-  ONLINE  = 'Online'       # Meant to be an "other" catch-all
-  ESTORE  = 'e-Store'      # This is going away . . .
-  PRINT   = 'Print'        # Books, pamphlets, Newsletter articles, etc. - physical media
-  MOKUJI  = 'Mokuji'
-  FORMATS = [YOUTUBE, CAMPUS, ESTORE, MOKUJI, FACEBOOK, PRINT, PODCAST, TAPE, CD, VHS, DISK, ONLINE]  # approximately most to least used
+  TAPE    = 'Tape'.freeze
+  CD      = 'CD'.freeze
+  VHS     = 'VHS'.freeze
+  DISK    = 'DVD/Blu-ray'.freeze
+  CAMPUS  = 'Campus'.freeze
+  YOUTUBE = 'YouTube'.freeze      # Is it helpful to make this distinct?
+  FACEBOOK = 'FaceBook'.freeze    # Is it helpful to make this distinct?
+  PODCAST = 'Podcast'.freeze
+  ONLINE  = 'Online'.freeze       # Meant to be an "other" catch-all
+  ESTORE  = 'e-Store'.freeze      # This is going away . . .
+  PRINT   = 'Print'.freeze        # Books, pamphlets, Newsletter articles, etc. - physical media
+  MOKUJI  = 'Mokuji'.freeze
+  FORMATS = [YOUTUBE, CAMPUS, ESTORE, MOKUJI, FACEBOOK, PRINT, PODCAST, TAPE, CD, VHS, DISK, ONLINE].freeze  # approximately most to least used
 
   MINUTES = 'minutes'.freeze
   HMS     = 'hh:mm'.freeze
-  TIME_FORMATS = [MINUTES, HMS]
+  TIME_FORMATS = [MINUTES, HMS].freeze
 
   # Presence of duration isn't validated - but in a few cases, it's just not applicable. When it isn't, we need a way to
   # ensure those don't get flagged by the "heart" query as needing attention because duration is blank.

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -71,8 +71,8 @@ class Publication < ApplicationRecord
     text = ['A']
     text << [duration, 'minute'] if duration.present?
     text << [format, 'publication']
+    text << [ 'from', pretty_date(published_on) ] if published_on.present?
     text << ['by', presentations.first.speaker_names] if presentations.present?
-    text << [ 'on', pretty_date(published_on) ] if published_on.present?
     text.join(' ')
   end
 
@@ -105,6 +105,10 @@ class Publication < ApplicationRecord
     ActionView::Base.full_sanitizer.sanitize(editors_notes)
   end
 
+  def clean_details
+    ActionView::Base.full_sanitizer.sanitize(details)
+  end
+
   # Hash of human-friendly CSV column names and the methods that get the data for CSV export
   TITLES_AND_METHODS = {
       'Name'              => :name,
@@ -113,10 +117,11 @@ class Publication < ApplicationRecord
       'Published On'      => :published_on,
       'Format'            => :format,
       'Duration'          => :duration,
-      'Notes'             => :notes,
+      'Notes'             => :notes,               # multi-part info, and details that distinguish one copy from another
       'Media URL'         => :url,
       'Presentation URL'  => :publication_url,
-      'Description'       => :clean_description,   # contains redundant info - not really used
+      'Description'       => :clean_description,   # contains a generated one-liner intended for FB meta data
+      'Details'           => :clean_details,       # contains supplemental
       'Editors Notes'     => :clean_editors_notes,
   }
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -34,6 +34,7 @@ class Publication < ApplicationRecord
   # Presence of duration isn't validated - but in a few cases, it's just not applicable. When it isn't, we need a way to
   # ensure those don't get flagged by the "heart" query as needing attention because duration is blank.
   HAS_DURATION = [ESTORE, YOUTUBE, CAMPUS, MOKUJI, FACEBOOK, PODCAST, TAPE, CD, VHS, DISK]
+  PHYSICAL     = [PRINT, TAPE, CD, VHS, DISK].freeze
 
   attr_accessor :ui_duration      # duration in hh:mm or hh:mm:ss or raw minutes
 
@@ -66,6 +67,11 @@ class Publication < ApplicationRecord
     HAS_DURATION.include? format
   end
 
+  # For determining which items can be in inventory at all
+  def physical?
+    PHYSICAL.include? format
+  end
+
   # synthesize a description for FB sharing
   def description
     text = ['A']
@@ -95,12 +101,11 @@ class Publication < ApplicationRecord
     Rails.application.routes.url_helpers.publication_url(self)
   end
 
-  # Gives the description with any HTML tags stripped out
+  # The "clean" methods give the contents of rich-text fields with any HTML tags stripped out (for CSV export)
   def clean_description
     ActionView::Base.full_sanitizer.sanitize(description)
   end
 
-  # Gives the description with any HTML tags stripped out
   def clean_editors_notes
     ActionView::Base.full_sanitizer.sanitize(editors_notes)
   end
@@ -117,6 +122,7 @@ class Publication < ApplicationRecord
       'Published On'      => :published_on,
       'Format'            => :format,
       'Duration'          => :duration,
+      'ARI Inventory'     => :ari_inventory,
       'Notes'             => :notes,               # multi-part info, and details that distinguish one copy from another
       'Media URL'         => :url,
       'Presentation URL'  => :publication_url,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,12 +3,12 @@ class Role < ApplicationRecord
   has_many :users
 
   # These values get defined in the DB by db_seeds. The db:norton task checks for modifications
-  ADMIN     = 'admin'
-  EDITOR    = 'editor'
-  READER    = 'reader'
+  ADMIN     = 'admin'.freeze
+  EDITOR    = 'editor'.freeze
+  READER    = 'reader'.freeze
 
   # Don't change the order of these, because the ability to reload them via rake db:seed relies on consistent ordering.
-  ROLES = [ADMIN, EDITOR, READER]
+  ROLES = [ADMIN, EDITOR, READER].freeze
 
   validates :name, presence: true, inclusion: ROLES
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -28,6 +28,12 @@ class Setting < ApplicationRecord
   private
 
   def self.get_settings
-    @setting = Setting.first
+    setting = Setting.first
+    if setting.blank?
+      # there isn't one - this can only happen in a brand new instance, or in testing
+      setting = Setting.new(base_event_year: 1959, speaker_chart_floor: 3)
+      setting.save!
+    end
+    @setting = setting
   end
 end

--- a/app/views/events/_conference.html.haml
+++ b/app/views/events/_conference.html.haml
@@ -6,8 +6,11 @@
   .col-md-2
     = location_with_non_us_country conference, :short
   .col.d-none.d-md-block.text-center
+    -# TODO 343 - show both the old and new program icons to help ensure all the data is ported over correctly
     - if conference.program_url.present?
       = link_to icon('far', 'file'), conference.program_url, target: '_blank'
+    - conference.programs.each do |program|
+      = linked_icon_for_program program
   - if can? :edit, Conference
     .col.d-none.d-md-block.text-center
       = icon('fas', 'check', :class => 'fa-lg fa-fw text-success') if conference.completed

--- a/app/views/events/_header.html.haml
+++ b/app/views/events/_header.html.haml
@@ -14,7 +14,7 @@
     = sorting_header 'Location', :events_path, 'concat(conferences.city, conferences.state)'
 
   .col.d-none.d-md-block.text-center
-    Program
+    Info
 
   - if can? :edit, Conference
     .col.d-none.d-md-block

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -55,10 +55,7 @@
               .col-md-9
                 %li= safe_list_sanitizer.sanitize(program.description).try(:html_safe)
               .col-md-3.text-right
-                - if program.url.present?
-                  = link_to icon('far', 'external-link-alt', class: 'fa-fw'), program.url, target: '_blank', title: program.name, class: 'mr-2'
-                - else
-                  = link_to icon('fas', 'file-pdf', class: 'fa-fw fa-lg'), download_event_program_path(@conference, program), target: '_blank', title: program.name, class: 'mr-2'
+                = linked_icon_for_program(program, link_classes: 'mr-2')
                 - if can? :edit, Program
                   = link_to icon('far', 'edit', class: 'fa-fw fa-sm'), edit_event_program_path(@conference, program), class: "btn btn-xs btn-primary mr-1"
                 - if can? :destroy, Program

--- a/app/views/presentations/_header.html.haml
+++ b/app/views/presentations/_header.html.haml
@@ -15,6 +15,11 @@
   - if params[:heart].present?
     .col Needs
 
-  .col.col-md-2.text-right Media
-  - if can? :edit, Presentation
-    .col.d-none.d-md-block
+  .col.col-sm-2.col-md-2.text-right
+    Media
+
+  - if current_user.present?
+    .col-sm-3
+      Me
+      - if can? :edit, Presentation
+        .col.d-none.d-md-block

--- a/app/views/presentations/show.html.haml
+++ b/app/views/presentations/show.html.haml
@@ -62,7 +62,7 @@
             = render :partial => 'publication', locals: { publication: publication }
 
       - if can?(:edit, @presentation)
-        %p= link_to icon('fas', 'search', 'Search for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
+        %p= link_to icon('fas', 'search', 'Search the internet for More', class: 'fa-fw'), google_search_url(@presentation), target: "_blank"
 
 - if can?(:edit, @presentation) # && @presentation.editors_notes.present?
   .row

--- a/app/views/programs/new.html.haml
+++ b/app/views/programs/new.html.haml
@@ -5,7 +5,7 @@
 .row
   .col-md-12
     %h3
-      Add a supplemental info to
+      Add supplemental info to
       = @event.name
     = simple_form_for [@event, @program], url: event_programs_path(@event), :html => {:autocomplete => "off"}  do |f|
       = render :partial => "form_fields", :locals => {:f => f}

--- a/app/views/publications/_form_fields.html.haml
+++ b/app/views/publications/_form_fields.html.haml
@@ -13,8 +13,9 @@
       = f.input :speaker_names, hint: 'Free text names - helpful later to find the matching presentation.'
 .row
   .col-md-12
-    = f.label :description
-    = f.trix_editor :description
+    = f.label :details
+    = f.trix_editor :details
+    .small.mb-3 Visible to everyone. Use for sourcing, history info, general background.
 
 .row
   .col-md-2
@@ -29,7 +30,7 @@
   .col-md-2
     = f.input :ui_duration, as: :string, label: 'Duration', input_html: { value: duration_for_display(@publication) }, hint: "duration in minutes or as hh:mm or hh:mm:ss"
   .col-md-10
-    = f.input :notes, hint: 'Users see this - label multi-part items here. Anything clarifying from a reader perspective.'
+    = f.input :notes, hint: 'Users see this in pubs list - label multi-part items here.'
 - if @presentation.present?
   .row
     .col-md-12
@@ -44,6 +45,6 @@
       = label_tag :canonical, label_text
 .row
   .col-md-12
-    = f.label "Editor's Notes"
+    = f.label "Editor's Notes", for: 'publication_editors_notes'
     = f.trix_editor :editors_notes
-    .small Only visible to other editors. Use for source documentation and any notes other editors might find useful.
+    .small.mb-3 Only visible to other editors. Use for source documentation and any notes other editors might find useful.

--- a/app/views/publications/_form_fields.html.haml
+++ b/app/views/publications/_form_fields.html.haml
@@ -43,6 +43,12 @@
       - label_text += '</i> presented at '.html_safe
       - label_text += @presentation.conference_name
       = label_tag :canonical, label_text
+
+- if @publication.physical?
+  .row
+    .col-md-12
+      = f.input :ari_inventory, as: :boolean, label: "In ARI inventory"
+
 .row
   .col-md-12
     = f.label "Editor's Notes", for: 'publication_editors_notes'

--- a/app/views/publications/show.html.haml
+++ b/app/views/publications/show.html.haml
@@ -39,6 +39,16 @@
       - else
         %i none
 
+.row
+  .col-md-12
+    %p
+      %b Details
+      %br
+      - if @publication.details.present?
+        = safe_list_sanitizer.sanitize(@publication.details).try(:html_safe)
+      - else
+        %i none
+
 - if can?(:edit, @publication)
   .row
     .col-md-12

--- a/app/views/publications/show.html.haml
+++ b/app/views/publications/show.html.haml
@@ -68,18 +68,18 @@
             = link_to icon('far', 'edit', :class => 'fa-fw'), edit_publication_path(@publication, presentation_id: presentation.id)
             = link_to icon('fas', 'unlink', :class => 'fa-fw'), presentation_publication_path(presentation_publication), :method => :delete, :post => true, class: 'text-danger'
 
--# If the controller identified possible related publications, list them for association
+-# Let the user find presentations to associate
 - if can?(:edit, @publication)
   .row
     .col-md-12
       %h4= "Associate a Presentation"
-
       = simple_form_for :presentation_publication, url: presentation_publications_path do |f|
         = f.input :publication_id, as: :hidden, input_html: { value: @publication.id }
         = f.input :presentation_id, collection: [['',0]], label: false, input_html: { data: { delimiter: ',', placeholder: "enter a presentation name...", source: presentations_path(format: :json), exclude: @current_presentation_ids }, class: "select2-autocomplete", id: "presentation_picker" }
         .text-right
           = f.submit 'Associate', class: 'btn btn-sm btn-primary'
 
+-# If the controller identified possible related publications, list them for association
 =# render :partial => 'automated_candidates'
 
 .row

--- a/app/views/publications/show.html.haml
+++ b/app/views/publications/show.html.haml
@@ -49,6 +49,16 @@
       - else
         %i none
 
+- if @publication.physical?
+  .row
+    .col-md-12
+      %p
+        %b In ARI Inventory:
+        - if @publication.ari_inventory
+          Yes
+        - else
+          Haven't found it yet
+
 - if can?(:edit, @publication)
   .row
     .col-md-12

--- a/db/migrate/20200125144425_add_details_to_publication.rb
+++ b/db/migrate/20200125144425_add_details_to_publication.rb
@@ -1,0 +1,5 @@
+class AddDetailsToPublication < ActiveRecord::Migration[5.2]
+  def change
+    add_column "publications", :details, :string
+  end
+end

--- a/db/migrate/20200125145559_add_ari_inventory_to_publication.rb
+++ b/db/migrate/20200125145559_add_ari_inventory_to_publication.rb
@@ -1,0 +1,7 @@
+class AddAriInventoryToPublication < ActiveRecord::Migration[5.2]
+  def change
+    # This is just a boolean because it's either found or not.
+    # There's no third unverified state - either we found it, or we haven't found it yet.
+    add_column "publications", :ari_inventory, :boolean, :default => false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_025035) do
+ActiveRecord::Schema.define(version: 2020_01_25_145559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_025035) do
     t.text "editors_notes"
     t.string "sortable_name"
     t.string "details"
+    t.boolean "ari_inventory", default: false, null: false
     t.index ["creator_id"], name: "index_publications_on_creator_id"
     t.index ["sortable_name"], name: "index_publications_on_sortable_name"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_025035) do
     t.string "speaker_names"
     t.text "editors_notes"
     t.string "sortable_name"
+    t.string "details"
     t.index ["creator_id"], name: "index_publications_on_creator_id"
     t.index ["sortable_name"], name: "index_publications_on_sortable_name"
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Speaker, type: :model do
 
       context "with a setting" do
         before do
-          setting = Setting.first
+          setting = Setting.first || Setting.create(base_event_year: 1958)
           setting.update base_event_year: 1952
         end
 
-        it "gets the setting value" do
+        it "gets the setting value not the default" do
           expect(Setting.base_event_year).to eq(1952)
         end
       end


### PR DESCRIPTION
Solves several problems that help with cleaning up and adding data on production:
- Add Tour to event types
- Add distinct ARI Inventory field to publications
- Add details to publication and 
- Show the new Program icons in the event listing along with the old one, so it's easier to check that all the old documents and links are ported over
- Fix a bug in speaker search that finds too many things